### PR TITLE
fix: min=0||max=0 case in rule size

### DIFF
--- a/src/rules/size.js
+++ b/src/rules/size.js
@@ -25,14 +25,16 @@ function size(rule, value, errors, options) {
         return false;
     }
 
-    let val = value;
-    const max = Number(rule.max);
-    const min = Number(rule.min);
+    // TODO: 2.x change to typeof rule.min === 'number' || typeof rule.max === 'number'
+    if (typeof rule.min !== 'undefined' || typeof rule.max !== 'undefined') {
+        let val = value;
+        const max = Number(rule.max);
+        const min = Number(rule.min);
 
-    if (min || max) {
         if (isStr) {
             val = Number(val);
         }
+
         if (val < min) {
             errors.push(
                 util.format(

--- a/test/size.spec.js
+++ b/test/size.spec.js
@@ -136,6 +136,26 @@ describe('size', () => {
                 }
             );
         });
+
+        it('error with min=0 or max=0', done => {
+            new Schema({
+                v: {
+                    min: 0,
+                },
+                v1: {
+                    max: 0,
+                },
+            }).validate(
+                {
+                    v: -1,
+                    v1: 1,
+                },
+                errors => {
+                    assert(errors.length === 2);
+                    done();
+                }
+            );
+        });
     })
 
     describe('validatePromise', () => {


### PR DESCRIPTION
修复 min=0 or max=0 的临界值场景